### PR TITLE
fix: resolve /setchannel CommandSignatureMismatch and improve command…

### DIFF
--- a/src/discord_bot.py
+++ b/src/discord_bot.py
@@ -152,34 +152,50 @@ class iRacingDiscordBot(Client):
             logger.error(f'Failed to register commands: {e}')
             # Continue with sync attempt even if registration failed
                   
-        # Check if we should use guild-specific sync
-        if TARGET_GUILD_ID:
+        # Check if we should use guild-specific sync (TEST_GUILD_ID takes precedence over TARGET_GUILD_ID)
+        TEST_GUILD_ID = os.getenv("TEST_GUILD_ID")
+        if TEST_GUILD_ID:
             try:
-                # Debug: Log tree state before sync
-                logger.info(f"Command tree state before sync - local: {len(self.tree.get_commands())}, global: {len(await self.tree.sync()) if hasattr(self.tree.sync, '__call__') else 'N/A'}")
-                
-                # Get the guild object
+                guild_id = int(TEST_GUILD_ID)
+                guild = self.get_guild(guild_id)
+                if not guild:
+                    logger.error(f"Test guild with ID {TEST_GUILD_ID} not found. Using global command sync instead.")
+                    synced = await self.tree.sync()
+                    logger.info(f'Falling back to global sync: successfully synced {len(synced)} command(s)')
+                else:
+                    logger.info(f"Using test guild: {guild.name} (ID: {guild.id}) for command sync")
+                    
+                    # Optional: Clear and re-seed commands (uncomment only when needed for hard reset)
+                    # logger.info("Clearing existing guild commands for hard reset...")
+                    # await self.tree.clear_commands(guild=guild)
+                    # logger.info("Copying global commands to guild...")
+                    # await self.tree.copy_global_to(guild=guild)
+                    
+                    synced = await self.tree.sync(guild=guild)
+                    logger.info(f'Test guild sync successful: synced {len(synced)} command(s)')
+                    if synced:
+                        logger.info(f"Synced commands: {[cmd.name for cmd in synced]}")
+            except Exception as e:
+                logger.error(f'Failed to sync commands to test guild {TEST_GUILD_ID}: {e}')
+                synced = await self.tree.sync()
+                logger.info(f'Falling back to global sync after test guild failure: synced {len(synced)} command(s)')
+        elif TARGET_GUILD_ID:
+            try:
                 guild = self.get_guild(TARGET_GUILD_ID)
                 if not guild:
                     logger.error(f"Guild with ID {TARGET_GUILD_ID} not found. Using global command sync instead.")
                     synced = await self.tree.sync()
                     logger.info(f'Falling back to global sync: successfully synced {len(synced)} command(s)')
-                    # Debug: Log synced commands
-                    if synced:
-                        logger.info(f"Synced commands: {[cmd.name for cmd in synced]}")
                 else:
                     logger.info(f"Found guild: {guild.name} (ID: {guild.id})")
-                    # Sync commands to specific guild (instant)
                     synced = await self.tree.sync(guild=guild)
-                    logger.info(f'Guild-specific sync successful for guild {TARGET_GUILD_ID}: synced {len(synced)} command(s)')
-                    # Debug: Log synced commands
+                    logger.info(f'Guild-specific sync successful: synced {len(synced)} command(s)')
                     if synced:
                         logger.info(f"Synced commands: {[cmd.name for cmd in synced]}")
             except Exception as e:
                 logger.error(f'Failed to sync commands to guild {TARGET_GUILD_ID}: {e}')
-                # Fall back to global sync if guild-specific sync fails
                 synced = await self.tree.sync()
-                logger.info(f'Falling back to global sync after guild-specific failure: successfully synced {len(synced)} command(s)')
+                logger.info(f'Falling back to global sync after guild failure: synced {len(synced)} command(s)')
         else:
             # Sync commands globally (may take up to 1 hour to propagate)
             try:
@@ -189,12 +205,6 @@ class iRacingDiscordBot(Client):
                 logger.error(f'Failed to sync commands globally: {e}')
         
         # Start the background poller task
-        # Add logger attribute for tests
-        self.logger = logger
-                
-        # Set test_mode flag (will be used by tests to control logging behavior)
-        self.test_mode = False
-                
         if not self.background_poller.is_running():
             self.background_poller.start()
             interval_seconds = get_poll_interval()

--- a/src/discord_bot.py
+++ b/src/discord_bot.py
@@ -19,12 +19,35 @@ from src.logging_config import setup_logging, get_logger, add_correlation_id, ge
 from src.circuit_breaker import discord_api_circuit_breaker, CircuitBreakerError
 
 # Import Discord.py classes
-from discord import Intents, Client, app_commands, TextChannel, Interaction, HTTPException
+from discord import Intents, TextChannel, Interaction, HTTPException, ChannelType
+from discord.ext import commands
+from discord import app_commands
+from discord.app_commands import AppCommandError, checks
 
 # Import logging configuration and circuit breaker
 from src.logging_config import setup_logging, get_logger, add_correlation_id, generate_correlation_id, get_logger_with_correlation
-from discord.app_commands import AppCommandError, checks
 from discord.ext import tasks
+
+# Environment debug utilities
+logger = get_logger(__name__)
+
+def redact(tok: str) -> str:
+    return tok[:6] + "…" if tok else "None"
+
+def env_debug(bot: commands.Bot):
+    logger.info("discord.py version: %s", getattr(app_commands, "__version__", "unknown"))
+    logger.info("App user: %s / app_id: %s", getattr(bot, "user", None), getattr(bot, "application_id", None))
+    logger.info("TOKEN(head): %s  TEST_GUILD_ID=%s  TARGET_GUILD_ID=%s",
+                redact(os.getenv("DISCORD_TOKEN")),
+                os.getenv("TEST_GUILD_ID"), os.getenv("TARGET_GUILD_ID"))
+    # Optional: repo/workdir & git
+    try:
+        import subprocess
+        root = subprocess.check_output(["bash","-lc","pwd"]).decode().strip()
+        rev  = subprocess.check_output(["bash","-lc","git rev-parse --short HEAD"], cwd=root).decode().strip()
+        logger.info("Workdir: %s  Git rev: %s", root, rev)
+    except Exception:
+        logger.info("Workdir/Git rev unavailable")
 
 # Import database functionality
 from src.database import init_db, SessionLocal
@@ -77,12 +100,15 @@ def get_test_friendly_logger(logger):
     """Simple wrapper to provide test-friendly logger interface"""
     return logger
 
-class iRacingDiscordBot(Client):
+class iRacingDiscordBot(commands.Bot):
     """Main Discord bot class for iRacing integration"""
     
     def __init__(self):
-        super().__init__(intents=intents)
-        self.tree = app_commands.CommandTree(self)
+        super().__init__(
+            command_prefix="!",
+            intents=intents,
+            application_id=int(os.getenv("APPLICATION_ID", "0"))  # Fallback for tests
+        )
         self.is_shutting_down = False
         
         # Initialize config with default values
@@ -135,75 +161,40 @@ class iRacingDiscordBot(Client):
         signal.signal(signal.SIGTERM, signal_handler)
         logger.info("Signal handlers registered successfully")
 
+    async def setup_hook(self):
+        """Setup hook called when the bot is ready to register commands"""
+        env_debug(self)  # Log environment info
+        
+        # Register all commands (they're already decorated, but explicit is better)
+        await self._register_commands()
+        
+        # Prefer guild-first sync if TEST_GUILD_ID available
+        test_gid = os.getenv("TEST_GUILD_ID")
+        if test_gid:
+            try:
+                g = discord.Object(id=int(test_gid))
+                synced = await self.tree.sync(guild=g)
+                logger.info("Synced %d commands to TEST_GUILD_ID=%s: %s",
+                            len(synced), test_gid, [c.name for c in synced])
+            except Exception as e:
+                logger.error(f"Failed to sync commands to test guild {test_gid}: {e}")
+                # Fall back to global sync
+                synced = await self.tree.sync()
+                logger.info("Falling back to global sync: synced %d command(s)", len(synced))
+        else:
+            try:
+                synced = await self.tree.sync()
+                logger.info("Synced %d commands globally", len(synced))
+            except Exception as e:
+                logger.error(f"Failed to sync commands globally: {e}")
+
     async def on_ready(self):
         """Called when the bot is ready and connected to Discord"""
         if self.user:
             logger.info(f'Logged in as {self.user} (ID: {self.user.id})')
         else:
             logger.warning('Bot user is not available (likely in test mode)')
-        
-        logger.info('Syncing slash commands...')
-        
-        # Register all commands before syncing
-        try:
-            await self._register_commands()
-            logger.info('All commands successfully registered with the command tree')
-        except Exception as e:
-            logger.error(f'Failed to register commands: {e}')
-            # Continue with sync attempt even if registration failed
-                  
-        # Check if we should use guild-specific sync (TEST_GUILD_ID takes precedence over TARGET_GUILD_ID)
-        TEST_GUILD_ID = os.getenv("TEST_GUILD_ID")
-        if TEST_GUILD_ID:
-            try:
-                guild_id = int(TEST_GUILD_ID)
-                guild = self.get_guild(guild_id)
-                if not guild:
-                    logger.error(f"Test guild with ID {TEST_GUILD_ID} not found. Using global command sync instead.")
-                    synced = await self.tree.sync()
-                    logger.info(f'Falling back to global sync: successfully synced {len(synced)} command(s)')
-                else:
-                    logger.info(f"Using test guild: {guild.name} (ID: {guild.id}) for command sync")
-                    
-                    # Optional: Clear and re-seed commands (uncomment only when needed for hard reset)
-                    # logger.info("Clearing existing guild commands for hard reset...")
-                    # await self.tree.clear_commands(guild=guild)
-                    # logger.info("Copying global commands to guild...")
-                    # await self.tree.copy_global_to(guild=guild)
-                    
-                    synced = await self.tree.sync(guild=guild)
-                    logger.info(f'Test guild sync successful: synced {len(synced)} command(s)')
-                    if synced:
-                        logger.info(f"Synced commands: {[cmd.name for cmd in synced]}")
-            except Exception as e:
-                logger.error(f'Failed to sync commands to test guild {TEST_GUILD_ID}: {e}')
-                synced = await self.tree.sync()
-                logger.info(f'Falling back to global sync after test guild failure: synced {len(synced)} command(s)')
-        elif TARGET_GUILD_ID:
-            try:
-                guild = self.get_guild(TARGET_GUILD_ID)
-                if not guild:
-                    logger.error(f"Guild with ID {TARGET_GUILD_ID} not found. Using global command sync instead.")
-                    synced = await self.tree.sync()
-                    logger.info(f'Falling back to global sync: successfully synced {len(synced)} command(s)')
-                else:
-                    logger.info(f"Found guild: {guild.name} (ID: {guild.id})")
-                    synced = await self.tree.sync(guild=guild)
-                    logger.info(f'Guild-specific sync successful: synced {len(synced)} command(s)')
-                    if synced:
-                        logger.info(f"Synced commands: {[cmd.name for cmd in synced]}")
-            except Exception as e:
-                logger.error(f'Failed to sync commands to guild {TARGET_GUILD_ID}: {e}')
-                synced = await self.tree.sync()
-                logger.info(f'Falling back to global sync after guild failure: synced {len(synced)} command(s)')
-        else:
-            # Sync commands globally (may take up to 1 hour to propagate)
-            try:
-                synced = await self.tree.sync()
-                logger.info(f'Global sync successful: synced {len(synced)} command(s) (may take up to 1 hour to propagate worldwide)')
-            except Exception as e:
-                logger.error(f'Failed to sync commands globally: {e}')
-        
+
         # Start the background poller task
         if not self.background_poller.is_running():
             self.background_poller.start()
@@ -667,7 +658,7 @@ class iRacingDiscordBot(Client):
     # Slash Command: /setchannel
     # ------------------------------
     @app_commands.command(name="setchannel", description="Set the channel for iRacing race announcements")
-    @app_commands.describe(channel="Text channel for announcements")
+    @app_commands.describe(channel="Target text channel for auto posts")
     @checks.has_permissions(administrator=True)
     async def setchannel(self, interaction: Interaction, channel: TextChannel):
         """Handle /setchannel command with administrator permission check"""
@@ -754,6 +745,89 @@ class iRacingDiscordBot(Client):
                 f"❌ An error occurred: {str(error)}",
                 ephemeral=True
             )
+
+async def diagnose_command_shapes(bot: commands.Bot):
+    """Diagnostic function to compare local vs remote command shapes"""
+    logger.info("Starting command shape diagnostic...")
+    
+    # Local view
+    local_commands = {c.name: getattr(c, "parameters", None) for c in bot.tree.get_commands()}
+    logger.info("LOCAL commands: %s", list(local_commands.keys()))
+    for name, params in local_commands.items():
+        if params is None:
+            continue
+        param_names = [getattr(p, "name", "?") for p in params]
+        param_types = [getattr(p, "type", "?") for p in params]
+        logger.info("LOCAL %s params: %s (types: %s)", name, param_names, param_types)
+
+    # Remote global
+    try:
+        remote_global = await bot.tree.fetch_commands()
+        logger.info("REMOTE GLOBAL commands: %s", [f"{c.name}#{c.id}" for c in remote_global])
+        for cmd in remote_global:
+            if hasattr(cmd, 'parameters'):
+                param_names = [getattr(p, "name", "?") for p in cmd.parameters]
+                logger.info("REMOTE GLOBAL %s params: %s", cmd.name, param_names)
+    except Exception as e:
+        logger.error("Failed to fetch remote global commands: %s", e)
+
+    # Remote per guild
+    try:
+        for g in bot.guilds:
+            r = await bot.tree.fetch_commands(guild=g)
+            logger.info("REMOTE guild %s (%s): %s", g.name, g.id, [f"{c.name}#{c.id}" for c in r])
+            for cmd in r:
+                if hasattr(cmd, 'parameters'):
+                    param_names = [getattr(p, "name", "?") for p in cmd.parameters]
+                    logger.info("REMOTE guild %s %s params: %s", g.name, cmd.name, param_names)
+    except Exception as e:
+        logger.error("Failed to fetch remote guild commands: %s", e)
+
+    logger.info("Command shape diagnostic completed")
+
+async def hard_reset_all_commands(bot: commands.Bot):
+    """Hard reset procedure: clear all remote commands and re-sync"""
+    logger.info("Starting hard reset of all commands...")
+    
+    # 1) Clear GLOBAL remote by clearing local tree then syncing globally
+    logger.info("Clearing global command tree...")
+    bot.tree.clear_commands()        # clears local tree for global scope
+    await bot.tree.sync()            # pushes "no commands" globally
+    logger.info("Global command tree cleared")
+
+    # 2) Clear per-guild remotes
+    try:
+        for g in bot.guilds:
+            logger.info("Clearing commands for guild %s (%s)...", g.name, g.id)
+            bot.tree.clear_commands(guild=g)
+            await bot.tree.sync(guild=g)
+            logger.info("Commands cleared for guild %s (%s)", g.name, g.id)
+    except Exception as e:
+        logger.error("Failed to clear some guild commands: %s", e)
+
+    # 3) Re-register all commands
+    logger.info("Re-registering all commands...")
+    await bot._register_commands()
+
+    # 4) Final re-sync (guild-first if TEST_GUILD_ID exists)
+    test_gid = os.getenv("TEST_GUILD_ID")
+    if test_gid:
+        try:
+            g = discord.Object(id=int(test_gid))
+            logger.info("Re-syncing with test guild %s...", test_gid)
+            await bot.tree.sync(guild=g)
+            logger.info("Test guild re-sync completed")
+        except Exception as e:
+            logger.error("Failed to re-sync test guild: %s", e)
+    else:
+        try:
+            logger.info("Re-syncing globally...")
+            await bot.tree.sync()
+            logger.info("Global re-sync completed")
+        except Exception as e:
+            logger.error("Failed to re-sync globally: %s", e)
+
+    logger.info("Hard reset procedure completed")
 
 # Signal handler for graceful shutdown
 def signal_handler(sig, frame):

--- a/tests/test_commands_signature.py
+++ b/tests/test_commands_signature.py
@@ -1,0 +1,47 @@
+import pytest
+import discord
+from discord.ext import commands
+from discord import app_commands
+from src.discord_bot import iRacingDiscordBot
+
+def test_setchannel_command_signature():
+    """Test that /setchannel command has the correct signature and properties"""
+    # Create a test bot instance
+    intents = discord.Intents.default()
+    intents.guilds = True
+    bot = iRacingDiscordBot()
+    
+    # Register commands (this would happen in on_ready in real usage)
+    import asyncio
+    asyncio.run(bot._register_commands())
+    
+    # Check that the command is registered
+    commands_in_tree = [cmd.name for cmd in bot.tree.get_commands()]
+    assert "setchannel" in commands_in_tree, "setchannel command should be registered in the tree"
+    
+    # Get the specific command
+    setchannel_cmd = None
+    for cmd in bot.tree.get_commands():
+        if cmd.name == "setchannel":
+            setchannel_cmd = cmd
+            break
+    
+    assert setchannel_cmd is not None, "Could not find setchannel command in tree"
+    
+    # Verify command properties
+    assert setchannel_cmd.name == "setchannel", f"Command name should be 'setchannel', got '{setchannel_cmd.name}'"
+    assert setchannel_cmd.description == "Set the channel for iRacing race announcements", \
+        f"setchannel description should be 'Set the channel for iRacing race announcements', got '{setchannel_cmd.description}'"
+    
+    # Verify parameter count and names
+    assert len(setchannel_cmd.parameters) == 1, \
+        f"setchannel should have exactly 1 parameter, got {len(setchannel_cmd.parameters)}"
+    
+    param = setchannel_cmd.parameters[0]
+    assert param.name == "channel", \
+        f"setchannel parameter should be named 'channel', got '{param.name}'"
+    
+    # Verify it's the only command with this name
+    setchannel_commands = [cmd for cmd in bot.tree.get_commands() if cmd.name == "setchannel"]
+    assert len(setchannel_commands) == 1, \
+        f"Found {len(setchannel_commands)} commands named 'setchannel', expected exactly 1"

--- a/tests/test_commands_signature.py
+++ b/tests/test_commands_signature.py
@@ -41,7 +41,134 @@ def test_setchannel_command_signature():
     assert param.name == "channel", \
         f"setchannel parameter should be named 'channel', got '{param.name}'"
     
+    # Verify parameter type is Channel with text restriction (or compatible)
+    from discord import app_commands, ChannelType
+    assert isinstance(param.type, app_commands.Channel), \
+        f"setchannel parameter should be of type app_commands.Channel, got '{param.type}'"
+    
+    # Verify the channel type restriction includes text channels
+    assert ChannelType.text in param.type.channel_types, \
+        f"setchannel parameter should accept text channels, got '{param.type.channel_types}'"
+    assert ChannelType.news in param.type.channel_types, \
+        f"setchannel parameter should accept news channels, got '{param.type.channel_types}'"
+    
     # Verify it's the only command with this name
     setchannel_commands = [cmd for cmd in bot.tree.get_commands() if cmd.name == "setchannel"]
     assert len(setchannel_commands) == 1, \
         f"Found {len(setchannel_commands)} commands named 'setchannel', expected exactly 1"
+
+def test_command_signature_lock():
+    """Test that command signatures are locked to prevent unexpected changes"""
+    intents = discord.Intents.default()
+    intents.guilds = True
+    bot = iRacingDiscordBot()
+    
+    import asyncio
+    asyncio.run(bot._register_commands())
+    
+    # Define the expected command structure
+    EXPECTED_COMMANDS = {
+        "setchannel": {
+            "description": "Set the channel for iRacing race announcements",
+            "parameters": [
+                {
+                    "name": "channel",
+                    "type": discord.TextChannel
+                }
+            ]
+        },
+        "lastrace": {
+            "description": "Get details about a user's most recent iRacing race",
+            "parameters": [
+                {
+                    "name": "customer_id",
+                    "type": str
+                }
+            ]
+        },
+        "trackmember": {
+            "description": "Track a specific iRacing member's activity",
+            "parameters": [
+                {
+                    "name": "customer_id",
+                    "type": str
+                }
+            ]
+        }
+    }
+    
+    # Verify each command matches expected structure
+    for cmd_name, expected in EXPECTED_COMMANDS.items():
+        cmd = None
+        for c in bot.tree.get_commands():
+            if c.name == cmd_name:
+                cmd = c
+                break
+        
+        assert cmd is not None, f"Command '{cmd_name}' not found in command tree"
+        assert cmd.description == expected["description"], \
+            f"Command '{cmd_name}' description mismatch: expected '{expected['description']}', got '{cmd.description}'"
+        
+        # Verify parameters
+        assert len(cmd.parameters) == len(expected["parameters"]), \
+            f"Command '{cmd_name}' parameter count mismatch: expected {len(expected['parameters'])}, got {len(cmd.parameters)}"
+        
+        for i, expected_param in enumerate(expected["parameters"]):
+            actual_param = cmd.parameters[i]
+            assert actual_param.name == expected_param["name"], \
+                f"Parameter {i} name mismatch in '{cmd_name}': expected '{expected_param['name']}', got '{actual_param.name}'"
+            assert actual_param.type == expected_param["type"], \
+                f"Parameter {i} type mismatch in '{cmd_name}': expected {expected_param['type']}, got {actual_param.type}"
+
+def test_hard_reset_procedure():
+    """Test that hard reset procedure can be called without errors"""
+    intents = discord.Intents.default()
+    intents.guilds = True
+    bot = iRacingDiscordBot()
+    
+    import asyncio
+    
+    # Mock the necessary methods to prevent actual API calls
+    original_clear_commands = bot.tree.clear_commands
+    original_sync = bot.tree.sync
+    original_register_commands = bot._register_commands
+    
+    # Mock implementations that don't make real API calls
+    bot.tree.clear_commands = lambda *args, **kwargs: None
+    bot.tree.sync = lambda *args, **kwargs: []
+    bot._register_commands = lambda: None
+    
+    try:
+        # This should not raise exceptions
+        asyncio.run(bot.hard_reset_all_commands())
+        assert True, "Hard reset procedure should complete without errors"
+    finally:
+        # Restore original methods
+        bot.tree.clear_commands = original_clear_commands
+        bot.tree.sync = original_sync
+        bot._register_commands = original_register_commands
+
+def test_diagnostic_function():
+    """Test that diagnostic function can be called without errors"""
+    intents = discord.Intents.default()
+    intents.guilds = True
+    bot = iRacingDiscordBot()
+    
+    import asyncio
+    
+    # Mock the necessary methods to prevent actual API calls
+    original_get_commands = bot.tree.get_commands
+    original_fetch_commands = bot.tree.fetch_commands
+    
+    # Mock implementations that don't make real API calls
+    bot.tree.get_commands = lambda: []
+    bot.tree.fetch_commands = lambda *args, **kwargs: []
+    
+    try:
+        # This should not raise exceptions
+        asyncio.run(bot.diagnose_command_shapes())
+        assert True, "Diagnostic function should complete without errors"
+    finally:
+        # Restore original methods
+        bot.tree.get_commands = original_get_commands
+        bot.tree.fetch_commands = original_fetch_commands


### PR DESCRIPTION
… sync reliability

- Add robust guild-first command sync on startup (TEST_GUILD_ID priority)
- Ensure single authoritative CommandTree usage throughout
- Add unit test to lock /setchannel signature (exactly one 'channel' parameter)
- Improve error handling and logging for command registration/sync
- Eliminate CommandSignatureMismatch errors for /setchannel command

Fixes issue where Discord cached command definitions didn't match current code signature.